### PR TITLE
adds main menu scene

### DIFF
--- a/scenes/animated_button/animated_button.gd
+++ b/scenes/animated_button/animated_button.gd
@@ -1,0 +1,2 @@
+class_name AnimatedButton
+extends Button

--- a/scenes/animated_button/animated_button.tscn
+++ b/scenes/animated_button/animated_button.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://7hnvbid1hrlp"]
+
+[ext_resource type="Script" path="res://scenes/animated_button/animated_button.gd" id="1_molr8"]
+
+[node name="AnimatedButton" type="Button"]
+offset_right = 8.0
+offset_bottom = 8.0
+text = "TEST TEXT"
+script = ExtResource("1_molr8")

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -1,3 +1,7 @@
-[gd_scene format=3 uid="uid://bin334p25nrp8"]
+[gd_scene load_steps=2 format=3 uid="uid://bin334p25nrp8"]
+
+[ext_resource type="PackedScene" uid="uid://crsrdjt56nbms" path="res://scenes/main_menu/main_menu.tscn" id="1_gnkoh"]
 
 [node name="Main" type="Node"]
+
+[node name="MainMenu" parent="." instance=ExtResource("1_gnkoh")]

--- a/scenes/main_menu/main_menu.gd
+++ b/scenes/main_menu/main_menu.gd
@@ -1,0 +1,27 @@
+class_name MainMenu
+extends CanvasLayer
+
+const FirstScene: PackedScene = preload("res://scenes/placeholder_level/placeholder_level.tscn")
+
+@onready var play_button_node: AnimatedButton = (
+	$MarginContainer/PanelContainer/MarginContainer/VBoxContainer/PlayButton
+) as AnimatedButton
+@onready var options_button_node: AnimatedButton = (
+	$MarginContainer/PanelContainer/MarginContainer/VBoxContainer/HowToButton
+) as AnimatedButton
+@onready var quit_button_node: AnimatedButton = (
+	$MarginContainer/PanelContainer/MarginContainer/VBoxContainer/QuitButton
+) as AnimatedButton
+
+
+func _ready() -> void:
+	play_button_node.pressed.connect(on_play_pressed)
+	quit_button_node.pressed.connect(on_quit_pressed)
+
+
+func on_play_pressed() -> void:
+	get_tree().change_scene_to_packed(FirstScene)
+
+
+func on_quit_pressed() -> void:
+	get_tree().quit()

--- a/scenes/main_menu/main_menu.tscn
+++ b/scenes/main_menu/main_menu.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=3 format=3 uid="uid://crsrdjt56nbms"]
+
+[ext_resource type="PackedScene" uid="uid://7hnvbid1hrlp" path="res://scenes/animated_button/animated_button.tscn" id="1_6oe2u"]
+[ext_resource type="Script" path="res://scenes/main_menu/main_menu.gd" id="1_wplja"]
+
+[node name="MainMenu" type="CanvasLayer"]
+script = ExtResource("1_wplja")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/PanelContainer"]
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="PlayButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer" instance=ExtResource("1_6oe2u")]
+layout_mode = 2
+text = "PLAY"
+
+[node name="HowToButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer" instance=ExtResource("1_6oe2u")]
+layout_mode = 2
+text = "HOW TO PLAY"
+
+[node name="QuitButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer" instance=ExtResource("1_6oe2u")]
+layout_mode = 2
+text = "QUIT"


### PR DESCRIPTION
Created a simple main menu scene with the default nodes of godot so the player can start the game (currently changing to the placeholder level) and quit (the how to play button does nothing for now) 
* The MainMenu scene is instantiated in the Main Scene
![image](https://github.com/pixelbearstudio/game-off-jam/assets/37094535/1915e969-0375-41c5-a632-af9d9db5a3ab)
* Current scopus of the menu scene
![image](https://github.com/pixelbearstudio/game-off-jam/assets/37094535/e5fa1311-6d57-4af8-8165-94a4f2fed2d8)
* Created a AnimatedButton scene that for now is just a simple button, but it can be animated latter to give better feedback to the player
![image](https://github.com/pixelbearstudio/game-off-jam/assets/37094535/8427065d-21e8-4dde-9c92-c1cd29c96770)
